### PR TITLE
[T07] Add an API route to get the number of course requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,190 +1,202 @@
 const express = require("express");
 const bodyParser = require("body-parser");
 const sql = require("mssql");
-const cors = require('cors');
-const app = express(); 
+const cors = require("cors");
+const app = express();
 
 // the classesQueries will hold all the functions handling SQL requests to the Classes table.
 const classesQueries = require("./queries/classes");
 // the cancellationRequestsQueries will hold all the functions handling SQL requests to the CancellationRequests table.
 const cancellationRequestsQueries = require("./queries/cancellation_requests");
+const courseRequestsQueries = require("./queries/course_requests");
 
 // import the dbConfig object from another file where we can hide it.
-const dbConfig = require("./logins")
+const dbConfig = require("./logins");
 
 // Body Parser Middleware
-app.use(bodyParser.json()); 
+app.use(bodyParser.json());
 app.use(cors());
 
 //Setting up server
- const server = app.listen(process.env.PORT || 8080, function () {
-    const port = server.address().port;
-    console.log("App now running on port", port);
- });
+const server = app.listen(process.env.PORT || 8080, function () {
+  const port = server.address().port;
+  console.log("App now running on port", port);
+});
 
 /**
  * Creates a new Cancellation Request.
- * 
+ *
  * The POST request to this endpoint should hold 2 parameters:
  * class_ID: the ID of the class that is requested to be cancelled
  * reason: the reason of the cancellation as indicated by the tutor
- * 
+ *
  * If successful, the request will return a status of 200, if not it will return the error as well as a status of 400.
  */
-app.post("/cancellation_request", function(req,res){
-    // Connecting to the database.
-    sql.connect(dbConfig, function (err) {   
-        if (err) console.log(err);
-        
-        const classID = req.body.class_ID;
-        const reason = req.body.reason;
-        if (reason === null) {
-            res.status(400).json({error:"The reason can not be null."})
-            return;
-        }
-        if (classID === null) {
-            res.status(400).json({error:"The classID can not be null."})
-            return;
-        }
+app.post("/cancellation_request", function (req, res) {
+  // Connecting to the database.
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
 
-        // Two checks are run prior to actually creating the record. Those checks are imbricated using callbacks. If both are successful, the final request will be run.
-        classesQueries.checkIfClassExistsWithID(sql,res,classID, () => {
-            cancellationRequestsQueries.checkIfNoPendingRequestForSameClass(sql, res, classID, () => {
-                cancellationRequestsQueries.createCancellationRequest(sql,res,classID,reason)
-            })
-        });
-        });
-        
+    const classID = req.body.class_ID;
+    const reason = req.body.reason;
+    if (reason === null) {
+      res.status(400).json({ error: "The reason can not be null." });
+      return;
+    }
+    if (classID === null) {
+      res.status(400).json({ error: "The classID can not be null." });
+      return;
+    }
+
+    // Two checks are run prior to actually creating the record. Those checks are imbricated using callbacks. If both are successful, the final request will be run.
+    classesQueries.checkIfClassExistsWithID(sql, res, classID, () => {
+      cancellationRequestsQueries.checkIfNoPendingRequestForSameClass(
+        sql,
+        res,
+        classID,
+        () => {
+          cancellationRequestsQueries.createCancellationRequest(
+            sql,
+            res,
+            classID,
+            reason
+          );
+        }
+      );
+    });
+  });
 });
 
 /**
  * TEST (This is a test route that needs to be removed before merging ticket T15 in)
- * 
+ *
  * It will return all the CancellationRequests records in the databse so you can check the CancellationRequests are created properly by the previous endpoint.
  */
-app.get("/cancellation_request_test", function(req,res){
-    // connect to your database
-    sql.connect(dbConfig, function (err) {   
+app.get("/cancellation_request_test", function (req, res) {
+  // connect to your database
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
 
+    // create Request object
+    const request = new sql.Request();
+
+    // query to the database and get the records
+    request.query(
+      "select * from CancellationRequests",
+      function (err, recordset) {
         if (err) console.log(err);
-
-        // create Request object
-        const request = new sql.Request();
-
-        // query to the database and get the records
-        request.query('select * from CancellationRequests', function (err, recordset) {
-
-            if (err) console.log(err)
-            // send records as a response
-            res.send(recordset);
-        });
-    });
-})
+        // send records as a response
+        res.send(recordset);
+      }
+    );
+  });
+});
 
 // Empty route to GET the number of course requests.
-app.get("/course_requests_number", function(req , res){
-    console.log("Request Received: GET number of course requests");
-    res.send("Course Request Number")
+app.get("/course_requests_number", function (req, res) {
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
+
+    courseRequestsQueries.getNumberOfCourseRequests(sql, res);
+  });
 });
 
 // Empty route to GET all the classes assigned to a tutor based on his/her Discord username.
-app.get("/tutor_classes/:discord_username", function(req , res){
-    console.log("Request Received: GET tutor classes whose status is unknown");
+app.get("/tutor_classes/:discord_username", function (req, res) {
+  console.log("Request Received: GET tutor classes whose status is unknown");
 });
 
 // Empty route to GET all the new course requests.
-app.get("/new_course_requests", function(req,res){
-    console.log("Request Received: GET new course requests");
+app.get("/new_course_requests", function (req, res) {
+  console.log("Request Received: GET new course requests");
 });
 
 // Empty route to POST new tutor demands.
-app.post("/tutor_demand", function(req,res){
-    console.log("Request Received: POST a tutor demand request");
-})
+app.post("/tutor_demand", function (req, res) {
+  console.log("Request Received: POST a tutor demand request");
+});
 
 // Empty route to POST reschedulling requests.
-app.post("/rescheduling_request", function(req,res){
-    console.log("Request Received: POST a reschedulling request");
-})
+app.post("/rescheduling_request", function (req, res) {
+  console.log("Request Received: POST a reschedulling request");
+});
 
 // Empty route to POST feedback requests.
-app.post("/feedback_creation", function(req,res){
-    console.log("Request Received: POST a feedback request");
-})
+app.post("/feedback_creation", function (req, res) {
+  console.log("Request Received: POST a feedback request");
+});
 
 /**
-  * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
-  * 
-  * GET all records from students table.
-  * Test URL: http://localhost:8080/students
-  */
- app.get('/students', function (req, res) {
-    // Connecting to the database.
-    sql.connect(dbConfig, function (err) {   
+ * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
+ *
+ * GET all records from students table.
+ * Test URL: http://localhost:8080/students
+ */
+app.get("/students", function (req, res) {
+  // Connecting to the database.
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
 
-        if (err) console.log(err);
+    // Creating a request object.
+    const request = new sql.Request();
 
-        // Creating a request object.
-        const request = new sql.Request();
-
-        // Running the query. 
-        request.query('select * from Students', function (err, recordset) {
-
-            if (err) console.log(err)
-            // Sending the records as a response.
-            res.send(recordset);
-        });
+    // Running the query.
+    request.query("select * from Students", function (err, recordset) {
+      if (err) console.log(err);
+      // Sending the records as a response.
+      res.send(recordset);
     });
+  });
 });
 
- /**
-  * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
-  * 
-  * This is to show how to insert one input INT value into SQL query. 
-  * Test URL: http://localhost:8080/students/1
-  */
-app.get('/students/:studentid', function (req, res) {
-    sql.connect(dbConfig, function (err) {   
+/**
+ * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
+ *
+ * This is to show how to insert one input INT value into SQL query.
+ * Test URL: http://localhost:8080/students/1
+ */
+app.get("/students/:studentid", function (req, res) {
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
 
-        if (err) console.log(err);
+    const request = new sql.Request();
 
-        const request = new sql.Request();
-        
-        request
-        .input('studentid', sql.Int, req.params.studentid)
-        .query('select * from Students where ID = @studentid', function (err, recordset) {
-            
-            if (err) console.log(err)
-            // send records as a response
-            res.send(recordset);
-            
-        });
-    });
+    request
+      .input("studentid", sql.Int, req.params.studentid)
+      .query(
+        "select * from Students where ID = @studentid",
+        function (err, recordset) {
+          if (err) console.log(err);
+          // send records as a response
+          res.send(recordset);
+        }
+      );
+  });
 });
 
- /**
-  * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
-  * 
-  * TThis is to show how to insert multiple inputs being INT and NVARCHAR. 
-  * Test URL: http://localhost:8080/students/3/Tuna (returns student id = 3 ALİ and Tuna)
-  */
- app.get('/students/:studentid/:studentname', function (req, res) {
-    // connect to your database
-        sql.connect(dbConfig, function (err) {   
-    
-            if (err) console.log(err);
-    
-            const request = new sql.Request();
-            
-            request
-            .input('studentid', sql.Int, req.params.studentid)
-            .input('studentname', sql.NVarChar, req.params.studentname)
-            .query('select * from Students where ID = @studentid or Name = @studentname', function (err, recordset) {
-                
-                if (err) console.log(err)
-                // send records as a response
-                res.send(recordset);
-                
-            });
-        });
-    });
+/**
+ * DEMO FUNCTION (this function only serves demonstration purposes and is to be deleted before delivering the API)
+ *
+ * TThis is to show how to insert multiple inputs being INT and NVARCHAR.
+ * Test URL: http://localhost:8080/students/3/Tuna (returns student id = 3 ALİ and Tuna)
+ */
+app.get("/students/:studentid/:studentname", function (req, res) {
+  // connect to your database
+  sql.connect(dbConfig, function (err) {
+    if (err) console.log(err);
+
+    const request = new sql.Request();
+
+    request
+      .input("studentid", sql.Int, req.params.studentid)
+      .input("studentname", sql.NVarChar, req.params.studentname)
+      .query(
+        "select * from Students where ID = @studentid or Name = @studentname",
+        function (err, recordset) {
+          if (err) console.log(err);
+          // send records as a response
+          res.send(recordset);
+        }
+      );
+  });
+});

--- a/app.js
+++ b/app.js
@@ -92,11 +92,14 @@ app.get("/cancellation_request_test", function (req, res) {
   });
 });
 
-// Empty route to GET the number of course requests.
+/**
+ * Get the total number of course requests in the database.
+ *
+ * If successful, the request will return a status of 200, if not it will return the error as well as a status of 400.
+ */
 app.get("/course_requests_number", function (req, res) {
   sql.connect(dbConfig, function (err) {
     if (err) console.log(err);
-
     courseRequestsQueries.getNumberOfCourseRequests(sql, res);
   });
 });

--- a/logins.js
+++ b/logins.js
@@ -1,8 +1,8 @@
 const dbConfig = {
-  user: "sa",
-  password: "KingsLabs@22/23#",
-  server: "198.244.247.123",
-  database: "enlightenlearning",
+  user: "username",
+  password: "pwd",
+  server: "ip",
+  database: "dbName",
   port: 1433,
   trustServerCertificate: true,
   encrypt: false,

--- a/logins.js
+++ b/logins.js
@@ -1,11 +1,11 @@
 const dbConfig = {
-    user:  "username",
-    password: "pwd",
-    server: "IP",
-    database: "dbName",
-    port: 1433,
-    trustServerCertificate: true,
-    encrypt: false
+  user: "sa",
+  password: "KingsLabs@22/23#",
+  server: "198.244.247.123",
+  database: "enlightenlearning",
+  port: 1433,
+  trustServerCertificate: true,
+  encrypt: false,
 };
 
-module.exports  = dbConfig;
+module.exports = dbConfig;

--- a/queries/course_requests.js
+++ b/queries/course_requests.js
@@ -1,0 +1,26 @@
+module.exports = {
+  /**
+   * Get the total number of course requests in the database.
+   *
+   * A status of 200 is given for successful requests. A status of 400 for unsuccessful ones.
+   *
+   * @param {*} sql The mssql instance connected to the database currently used by the API.
+   * @param {*} res The object to send result to a given query sender.
+   */
+  getNumberOfCourseRequests: function (sql, res) {
+    const request = new sql.Request();
+
+    request.query(
+      "SELECT COUNT(ID) FROM CourseRequests WHERE Status=0",
+      function (err, recordset) {
+        if (err) {
+          res.status(400).json({ error: err });
+        }
+
+        res
+          .status(200)
+          .json({ number: Object.values(recordset.recordset[0])[0] });
+      }
+    );
+  },
+};


### PR DESCRIPTION
Endpoint configured to get the number of course requests works.

I've added some logic to count only those with a new status. @TunaAtasayar what do you think of it? With the new course request life cycle we put together last week we could in fact just count the number of new course requests and if it's >=1 send the messages to discord. U just have to confirm that the dashboard creates them with a status of 0.

Did the testing but there are no inputs so no boundaries. Not much more to test but pls lemme know if u find a bug.

THanks!